### PR TITLE
Create .npmignore and configure package files

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -43,6 +43,9 @@
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.3"
   },
+  "files": [
+    "dist/"
+  ],
   "engines": {
     "node": ">=18.0.0"
   }


### PR DESCRIPTION
## Summary
- Adds `"files": ["dist/"]` to `cli/package.json` to whitelist only compiled output in the published npm package
- Reduces package size from ~165KB+ to ~11.3KB by excluding `src/`, `tsconfig.json`, `package-lock.json`, and other dev files
- `npm pack --dry-run` confirms only `dist/` and `package.json` are included (25 files, 11.3KB)

## Test plan
- [x] All existing tests pass (7/7)
- [x] `npm pack --dry-run` lists only `dist/` files and `package.json`
- [x] Package size is 11.3KB, well under the 500KB acceptance criterion

Closes SOF-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)