### PR TITLE
Update GitHub repo licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 CJ Nwangwu
+Copyright (c) 2026 CJ Nwangwu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/client/package.json
+++ b/client/package.json
@@ -44,5 +44,5 @@
   "description": "This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).",
   "main": "index.js",
   "author": "chib",
-  "license": "ISC"
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Renamed `LICENSE.md` → `LICENSE` for standard GitHub license badge detection
- Updated copyright year from `2023` to `2026`
- Fixed `client/package.json` license field from `ISC` to `MIT` to match the rest of the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)