### PR TITLE
docs: add README to cli package for npm page

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,137 @@
+# Transcribly
+
+Transcribe YouTube videos and local audio/video files from your terminal using the OpenAI Whisper API.
+
+```bash
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID
+```
+
+Transcript prints to your terminal and saves to `./text/`.
+
+## Prerequisites
+
+- **Node.js 18+**
+- **FFmpeg** — must be available in your `PATH`
+- **Python 3.8+** — required by `yt-dlp` for YouTube downloads
+- **OpenAI API key** — get one at [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+
+Run `transcribly --doctor` to verify everything is set up correctly.
+
+### Install FFmpeg
+
+```bash
+# macOS
+brew install ffmpeg
+
+# Linux (Debian/Ubuntu)
+sudo apt install ffmpeg
+
+# Windows (Chocolatey)
+choco install ffmpeg
+
+# Windows (winget)
+winget install ffmpeg
+```
+
+## API Key Setup
+
+```bash
+# Environment variable
+export OPENAI_API_KEY="sk-..."
+
+# Or pass it directly
+npx transcribly <url> --api-key sk-...
+
+# Or add to a .env file in your working directory
+OPENAI_API_KEY=sk-...
+```
+
+Run `transcribly --setup` for an interactive setup prompt.
+
+## Usage
+
+### Transcribe a YouTube video
+
+```bash
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID
+```
+
+### Transcribe a local file
+
+```bash
+npx transcribly file ./interview.mp3
+```
+
+### Pipe to another tool
+
+```bash
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | claude "Summarise this"
+```
+
+### Save as JSON
+
+```bash
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID --format json
+```
+
+### Pipe output to a file
+
+```bash
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID > transcript.txt
+```
+
+## Options
+
+| Option | Description | Default |
+|---|---|---|
+| `-o, --output <dir>` | Output directory for transcript files | `./text` |
+| `-f, --format <format>` | Output format: `txt` or `json` | `txt` |
+| `-k, --api-key <key>` | OpenAI API key (overrides env var) | — |
+| `--doctor` | Check all system dependencies | — |
+| `--setup` | Set up OpenAI API key interactively | — |
+
+## Output Format
+
+**Text (default)** — plain transcript saved to `./text/<video-id>.txt`
+
+**JSON** — structured output saved to `./text/<video-id>.json`:
+
+```json
+{
+  "audioFile": "/path/to/audio.mp3",
+  "transcript": "The full transcript text..."
+}
+```
+
+## Supported File Formats
+
+`mp3` `mp4` `wav` `webm` `m4a` `ogg` `flac` `mpeg` `mpga`
+
+Files larger than 24 MB are automatically split into chunks before transcription.
+
+## Global Install
+
+```bash
+npm install -g transcribly
+transcribly https://www.youtube.com/watch?v=VIDEO_ID
+```
+
+## Programmatic Usage
+
+```js
+const { transcribe } = require("transcribly/dist/transcriber");
+
+(async () => {
+  const result = await transcribe("./audio.mp3", process.env.OPENAI_API_KEY);
+  console.log(result.transcript);
+})();
+```
+
+## Links
+
+- Website: [transcribly.dev](https://transcribly.dev)
+- npm: [npmjs.com/package/transcribly](https://www.npmjs.com/package/transcribly)
+
+## License
+
+[MIT](../LICENSE.md)


### PR DESCRIPTION
## Summary

- Adds `cli/README.md` so the npm package page displays documentation
- Covers prerequisites, API key setup, usage examples, options table, supported formats, and programmatic usage

## Test plan

- [ ] Merge into master
- [ ] Run `npm publish` from the `cli/` directory
- [ ] Verify the README renders correctly on the npm package page at npmjs.com/package/transcribly

🤖 Generated with [Claude Code](https://claude.com/claude-code)