### PR TITLE
feat: improve API key onboarding with verbose error and OpenAI link

### DIFF
--- a/cli/src/dependencies.ts
+++ b/cli/src/dependencies.ts
@@ -126,7 +126,8 @@ export async function runDoctor(): Promise<void> {
     console.log(chalk.green("  ✓ OpenAI API key configured"));
   } else {
     console.log(chalk.red("  ✗ OpenAI API key not configured"));
-    console.log(chalk.yellow("    Run: transcribly --setup"));
+    console.log(chalk.yellow("    Get a key → https://platform.openai.com/api-keys"));
+    console.log(chalk.yellow("    Then run:  transcribly --setup"));
     allPassed = false;
   }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -104,16 +104,23 @@ function getApiKey(options: CommandOptions): string {
   if (process.env.OPENAI_API_KEY) return process.env.OPENAI_API_KEY;
 
   // No key found — show helpful error
+  console.error(chalk.red("\nError: No OpenAI API key found.\n"));
   console.error(
-    chalk.red("Error: OpenAI API key required for transcription.\n")
+    chalk.white("Transcribly uses the OpenAI Whisper API to transcribe audio.")
   );
-  console.error("Set it up in one of these ways:");
-  console.error("  1. Run: transcribly --setup");
-  console.error('  2. Set env var: export OPENAI_API_KEY="sk-..."');
-  console.error("  3. Add to .env file: OPENAI_API_KEY=sk-...");
   console.error(
-    "\nGet your API key at: https://platform.openai.com/api-keys"
+    chalk.white("You'll need a free API key from OpenAI to get started.\n")
   );
+  console.error(
+    chalk.cyan("  Get your API key → https://platform.openai.com/api-keys\n")
+  );
+  console.error(chalk.white("Once you have a key, set it up in one of these ways:\n"));
+  console.error(chalk.green("  Option 1 (recommended) — interactive setup:"));
+  console.error("    transcribly --setup\n");
+  console.error(chalk.green("  Option 2 — environment variable:"));
+  console.error('    export OPENAI_API_KEY="sk-..."\n');
+  console.error(chalk.green("  Option 3 — .env file in your working directory:"));
+  console.error("    OPENAI_API_KEY=sk-...\n");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

- When no API key is found, the error message now clearly explains what Whisper is, why a key is needed, and links directly to the OpenAI API keys page
- All three setup options (interactive setup, env var, .env file) are listed with clear labels
- `--doctor` output also now shows the OpenAI link alongside the setup command hint

## Before

```
Error: OpenAI API key required for transcription.

Set it up in one of these ways:
  1. Run: transcribly --setup
  2. Set env var: export OPENAI_API_KEY="sk-..."
  3. Add to .env file: OPENAI_API_KEY=sk-...

Get your API key at: https://platform.openai.com/api-keys
```

## After

```
Error: No OpenAI API key found.

Transcribly uses the OpenAI Whisper API to transcribe audio.
You'll need a free API key from OpenAI to get started.

  Get your API key → https://platform.openai.com/api-keys

Once you have a key, set it up in one of these ways:

  Option 1 (recommended) — interactive setup:
    transcribly --setup

  Option 2 — environment variable:
    export OPENAI_API_KEY="sk-..."

  Option 3 — .env file in your working directory:
    OPENAI_API_KEY=sk-...
```

## Test plan

- [x] Run `transcribly <url>` with no API key set — verify new message appears
- [x] Run `transcribly --doctor` with no API key — verify link is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)