### PR TITLE
fix: prevent hero title from overflowing on small mobile screens

### DIFF
--- a/client/src/components/landing/HeroSection.jsx
+++ b/client/src/components/landing/HeroSection.jsx
@@ -104,10 +104,9 @@ export default function HeroSection() {
           transition={{ duration: 0.7, delay: 0.4 }}
           className="mx-auto mb-6 max-w-3xl"
         >
-          <h1 className="text-left text-4xl font-extrabold tracking-tight text-white sm:text-5xl md:text-6xl lg:text-7xl">
-            <span className="whitespace-nowrap">Transcribe anything.</span>
-            <br />
-            <span className="inline-block min-h-[1.15em] text-green-400">
+          <h1 className="text-left text-3xl font-extrabold tracking-tight text-white sm:text-5xl md:text-6xl lg:text-7xl">
+            <span className="block sm:whitespace-nowrap">Transcribe anything.</span>
+            <span className="block min-h-[1.15em] text-green-400">
               {typedText || "\u00A0"}
             </span>
           </h1>


### PR DESCRIPTION
## Summary

The hero `<h1>` was using `whitespace-nowrap` with `text-4xl` (36px), which made "Transcribe anything." wider than the viewport on phones like the iPhone 12 Pro (390px). The text was getting clipped at both edges.

## Changes

- Dropped the base font size from `text-4xl` to `text-3xl` so the title fits comfortably on mobile (still scales up to `text-5xl` / `text-6xl` / `text-7xl` at sm/md/lg breakpoints — desktop look is unchanged)
- Replaced `<br />` + inline spans with two `block` spans for cleaner line break semantics
- Scoped `whitespace-nowrap` to `sm:` and up so the title can wrap gracefully on very narrow phones if needed

## Test plan

- [ ] Open transcribly.dev on iPhone 12 Pro (or DevTools mobile view at 390px) — confirm "Transcribe anything." fits with comfortable side padding
- [ ] Verify desktop (sm and up) still renders the original large hero
- [ ] Spot-check the typed second line ("In your terminal.", "Local audio files.", etc.) doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)