### PR TITLE
fix: keep hero title on a single line across all mobile widths

### DIFF
--- a/client/src/components/landing/HeroSection.jsx
+++ b/client/src/components/landing/HeroSection.jsx
@@ -104,9 +104,9 @@ export default function HeroSection() {
           transition={{ duration: 0.7, delay: 0.4 }}
           className="mx-auto mb-6 max-w-3xl"
         >
-          <h1 className="text-left text-3xl font-extrabold tracking-tight text-white sm:text-5xl md:text-6xl lg:text-7xl">
-            <span className="block sm:whitespace-nowrap">Transcribe anything.</span>
-            <span className="block min-h-[1.15em] text-green-400">
+          <h1 className="text-left text-[clamp(1.25rem,6.5vw,1.875rem)] font-extrabold tracking-tight text-white sm:text-5xl md:text-6xl lg:text-7xl">
+            <span className="block whitespace-nowrap">Transcribe anything.</span>
+            <span className="block min-h-[1.15em] whitespace-nowrap text-green-400">
               {typedText || "\u00A0"}
             </span>
           </h1>


### PR DESCRIPTION
## Summary

PR #62 reduced the hero title to text-3xl (30px) on mobile, but on iPhone 12 Pro (390px) and similar widths "Transcribe anything." was still wider than the available container, so it wrapped onto two lines.

This PR replaces the fixed text-3xl with a fluid clamp() that scales the font size with viewport width and keeps the title on a single line at every common phone size.

## Change

In client/src/components/landing/HeroSection.jsx:

- Mobile font size: text-[clamp(1.25rem,6.5vw,1.875rem)]
  - 20px floor at very small phones (e.g. iPhone SE 320px)
  - ~25px at iPhone 12 Pro 390px
  - 30px ceiling, matching the previous text-3xl
- whitespace-nowrap is now applied at all sizes (previously sm: only)
- Same nowrap also applied to the typed second line so it never wraps either
- Desktop sizes (sm: text-5xl, md: text-6xl, lg: text-7xl) are unchanged — web view stays exactly the same

## Test plan

- [ ] iPhone 12 Pro (390px) — "Transcribe anything." sits on one line with comfortable padding
- [ ] iPhone SE / 320px — title still fits on one line
- [ ] sm breakpoint and up — desktop hero looks identical to before