### PR TITLE
docs: replace broken pipe-to-claude example with verified per-agent recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,30 @@ npx transcribly file ./interview.mp3
 npx transcribly https://www.youtube.com/watch?v=VIDEO_ID > transcript.txt
 ```
 
-### Pipe to another tool
+### Use the transcript with an AI agent
+
+Each agent CLI handles piped stdin a little differently. Use whichever pattern matches your tool — they all end with the agent processing the transcript.
+
+**Codex** — pipe directly, stdin becomes the prompt:
 
 ```bash
-npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | claude "Summarise this"
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | codex exec --skip-git-repo-check
 ```
+
+**GitHub Copilot CLI** — pipe directly without a `-p` flag:
+
+```bash
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | copilot
+```
+
+**Claude** — Claude's CLI bails on slow stdin (3-second timeout), so write the transcript to a file first, then feed it in:
+
+```bash
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID > /tmp/t.txt && \
+  claude -p "Summarise this" < /tmp/t.txt
+```
+
+The file-based pattern also works as a universal fallback for any agent or downstream tool (grep, jq, your own scripts, etc.).
 
 ### Save as JSON
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -62,11 +62,30 @@ npx transcribly https://www.youtube.com/watch?v=VIDEO_ID
 npx transcribly file ./interview.mp3
 ```
 
-### Pipe to another tool
+### Use the transcript with an AI agent
+
+Each agent CLI handles piped stdin a little differently. Use whichever pattern matches your tool — they all end with the agent processing the transcript.
+
+**Codex** — pipe directly, stdin becomes the prompt:
 
 ```bash
-npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | claude "Summarise this"
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | codex exec --skip-git-repo-check
 ```
+
+**GitHub Copilot CLI** — pipe directly without a `-p` flag:
+
+```bash
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | copilot
+```
+
+**Claude** — Claude's CLI bails on slow stdin (3-second timeout), so write the transcript to a file first, then feed it in:
+
+```bash
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID > /tmp/t.txt && \
+  claude -p "Summarise this" < /tmp/t.txt
+```
+
+The file-based pattern also works as a universal fallback for any agent or downstream tool (grep, jq, your own scripts, etc.).
 
 ### Save as JSON
 


### PR DESCRIPTION
## Summary

Updates both READMEs (root and cli/) to replace the misleading 'transcribly | claude' example with the recipes that have actually been verified end-to-end on real runs.

## Why

The original 'npx transcribly <url> | claude \"summarise\"' example never worked — agent CLIs all handle piped stdin from a slow producer differently:

- Claude bails after a hardcoded 3 second stdin timeout
- Copilot's '-p' flag puts it in a mode that ignores stdin entirely
- Codex needs the 'exec' subcommand and '--skip-git-repo-check' flag

We verified working invocations for all three and now document them.

## What works (verified by real runs)

- Codex:   transcribly <url> | codex exec --skip-git-repo-check
- Copilot: transcribly <url> | copilot   (no -p)
- Claude:  transcribly <url> > /tmp/t.txt && claude -p '...' < /tmp/t.txt

The Claude file-buffered form is also presented as a universal fallback for grep, jq, custom scripts, etc.

## Files changed

- README.md
- cli/README.md (same content so the npm page matches)

## Follow-ups (out of scope)

- Once 1.0.3 lands with --out-file (if we ship that), update these examples to use it for shorter commands
- File a Claude Code issue requesting a configurable stdin timeout