### PR TITLE
feat: add --out-file flag and bump to 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ transcribly file ./path/to/audio.mp3
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-o, --output <dir>` | Output directory for transcript files | `./text` |
+| `--out-file <path>` | Write transcript to a specific file (overrides `--output`) | -- |
 | `-f, --format <format>` | Output format: `txt` or `json` | `txt` |
 | `-k, --api-key <key>` | OpenAI API key (overrides `OPENAI_API_KEY` env var) | -- |
 | `--doctor` | Check all system dependencies and report status | -- |

--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | codex exec --skip-git
 npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | copilot
 ```
 
-**Claude** — Claude's CLI bails on slow stdin (3-second timeout), so write the transcript to a file first, then feed it in:
+**Claude** — Claude's CLI bails on slow stdin (3-second timeout), so write the transcript to a file first, then feed it in. Use the `--out-file` flag for a clean one-liner:
 
 ```bash
-npx transcribly https://www.youtube.com/watch?v=VIDEO_ID > /tmp/t.txt && \
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID --out-file /tmp/t.txt && \
   claude -p "Summarise this" < /tmp/t.txt
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -78,10 +78,10 @@ npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | codex exec --skip-git
 npx transcribly https://www.youtube.com/watch?v=VIDEO_ID | copilot
 ```
 
-**Claude** — Claude's CLI bails on slow stdin (3-second timeout), so write the transcript to a file first, then feed it in:
+**Claude** — Claude's CLI bails on slow stdin (3-second timeout), so write the transcript to a file first, then feed it in. Use the `--out-file` flag for a clean one-liner:
 
 ```bash
-npx transcribly https://www.youtube.com/watch?v=VIDEO_ID > /tmp/t.txt && \
+npx transcribly https://www.youtube.com/watch?v=VIDEO_ID --out-file /tmp/t.txt && \
   claude -p "Summarise this" < /tmp/t.txt
 ```
 
@@ -104,6 +104,7 @@ npx transcribly https://www.youtube.com/watch?v=VIDEO_ID > transcript.txt
 | Option | Description | Default |
 |---|---|---|
 | `-o, --output <dir>` | Output directory for transcript files | `./text` |
+| `--out-file <path>` | Write transcript to a specific file (overrides `--output`) | — |
 | `-f, --format <format>` | Output format: `txt` or `json` | `txt` |
 | `-k, --api-key <key>` | OpenAI API key (overrides env var) | — |
 | `--doctor` | Check all system dependencies | — |

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transcribly",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transcribly",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transcribly",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "CLI tool to transcribe YouTube videos and local audio/video files using OpenAI Whisper API",
   "main": "dist/index.js",
   "bin": {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -27,12 +27,13 @@ program
   .description(
     "Transcribe YouTube videos and local audio/video files using OpenAI Whisper API"
   )
-  .version("1.0.0");
+  .version("1.0.3");
 
 program
   .command("url <youtube-url>")
   .description("Transcribe a YouTube video")
   .option("-o, --output <dir>", "Output directory", "./text")
+  .option("--out-file <path>", "Write transcript to a specific file (overrides --output)")
   .option("-f, --format <format>", "Output format (txt or json)", "txt")
   .option("-k, --api-key <key>", "OpenAI API key")
   .action(async (url: string, options) => {
@@ -43,6 +44,7 @@ program
   .command("file <path>")
   .description("Transcribe a local audio/video file")
   .option("-o, --output <dir>", "Output directory", "./text")
+  .option("--out-file <path>", "Write transcript to a specific file (overrides --output)")
   .option("-f, --format <format>", "Output format (txt or json)", "txt")
   .option("-k, --api-key <key>", "OpenAI API key")
   .action(async (filePath: string, options) => {
@@ -53,6 +55,7 @@ program
 program
   .argument("[input]", "YouTube URL or local file path")
   .option("-o, --output <dir>", "Output directory", "./text")
+  .option("--out-file <path>", "Write transcript to a specific file (overrides --output)")
   .option("-f, --format <format>", "Output format (txt or json)", "txt")
   .option("-k, --api-key <key>", "OpenAI API key")
   .option("--setup", "Set up OpenAI API key interactively")
@@ -79,6 +82,7 @@ program
 
 interface CommandOptions {
   output: string;
+  outFile?: string;
   format: string;
   apiKey?: string;
 }
@@ -297,8 +301,17 @@ function saveOutput(
   options: CommandOptions
 ): void {
   const format = options.format as "txt" | "json";
-  ensureOutputDir(options.output);
-  const outputPath = getOutputFilePath(options.output, baseName, format);
+
+  let outputPath: string;
+  if (options.outFile) {
+    // Explicit file path — use it directly and ensure its parent dir exists
+    outputPath = path.resolve(options.outFile);
+    const parentDir = path.dirname(outputPath);
+    ensureOutputDir(parentDir);
+  } else {
+    ensureOutputDir(options.output);
+    outputPath = getOutputFilePath(options.output, baseName, format);
+  }
 
   if (format === "json") {
     const jsonOutput = {


### PR DESCRIPTION
## Summary

Adds a new --out-file <path> option that writes the transcript to a specific file path, bypassing the default ./text/<videoId>.txt naming. This makes the agent-pipe recipe a clean one-liner.

## Why

The agent-pipe story documented in #70 still has friction:

```
npx transcribly <url> > /tmp/t.txt && claude -p '...' < /tmp/t.txt
```

This requires the user to pick a temp path twice. With --out-file, transcribly handles the file directly:

```
npx transcribly <url> --out-file /tmp/t.txt && claude -p '...' < /tmp/t.txt
```

Same pattern, but the file gets written cleanly without also dumping the transcript to ./text/<id>.txt.

## Changes

- cli/src/index.ts — adds --out-file option to all three command forms (url, file, default), updates CommandOptions interface, modifies saveOutput() to use the explicit path when set
- cli/package.json — version 1.0.2 → 1.0.3
- cli/package-lock.json — refreshed
- README.md and cli/README.md — Claude example updated to use --out-file
- cli/README.md options table — adds --out-file row

## Verified

- Built locally with npm run build
- All 24 existing tests pass (jest)
- End-to-end: ran the built cli with --out-file /tmp/transcribly-test.txt against a real YouTube short — transcript written to exact path, no ./text/ dir created

## After merge

- Tag v1.0.3 — publish workflow ships to npm so the page reflects the new examples and flag