### PR TITLE
feat: add Instagram video and reel transcription

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -81,6 +81,8 @@ program
     }
   });
 
+const SUPPORTED_URL_PLATFORMS = ["YouTube", "Instagram"];
+
 interface CommandOptions {
   output: string;
   outFile?: string;
@@ -234,7 +236,7 @@ async function handleTranscribeUrl(
   const isIG = isInstagramUrl(url);
 
   if (!isYT && !isIG) {
-    console.error(chalk.red("Error: Invalid URL. Only YouTube and Instagram URLs are supported."));
+    console.error(chalk.red(`Error: Unsupported URL. Supported platforms: ${SUPPORTED_URL_PLATFORMS.join(", ")}.`));
     process.exit(1);
   }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -7,6 +7,7 @@ import chalk from "chalk";
 import { config } from "dotenv";
 import { transcribe, TranscriptionResult } from "./transcriber";
 import { downloadYouTubeAudio, isYouTubeUrl } from "./youtube";
+import { downloadInstagramAudio, isInstagramUrl } from "./instagram";
 import {
   validateFilePath,
   createTempDir,
@@ -25,13 +26,13 @@ const program = new Command();
 program
   .name("transcribly")
   .description(
-    "Transcribe YouTube videos and local audio/video files using OpenAI Whisper API"
+    "Transcribe YouTube videos, Instagram reels, and local audio/video files using OpenAI Whisper API"
   )
   .version("1.0.3");
 
 program
-  .command("url <youtube-url>")
-  .description("Transcribe a YouTube video")
+  .command("url <url>")
+  .description("Transcribe a YouTube or Instagram video")
   .option("-o, --output <dir>", "Output directory", "./text")
   .option("--out-file <path>", "Write transcript to a specific file (overrides --output)")
   .option("-f, --format <format>", "Output format (txt or json)", "txt")
@@ -73,7 +74,7 @@ program
       program.help();
       return;
     }
-    if (isYouTubeUrl(input)) {
+    if (isYouTubeUrl(input) || isInstagramUrl(input)) {
       await handleTranscribeUrl(input, options);
     } else {
       await handleTranscribeFile(input, options);
@@ -229,8 +230,11 @@ async function handleTranscribeUrl(
 ): Promise<void> {
   const apiKey = getApiKey(options);
 
-  if (!isYouTubeUrl(url)) {
-    console.error(chalk.red("Error: Invalid YouTube URL."));
+  const isYT = isYouTubeUrl(url);
+  const isIG = isInstagramUrl(url);
+
+  if (!isYT && !isIG) {
+    console.error(chalk.red("Error: Invalid URL. Only YouTube and Instagram URLs are supported."));
     process.exit(1);
   }
 
@@ -257,7 +261,9 @@ async function handleTranscribeUrl(
   const tempDir = createTempDir();
 
   try {
-    const downloadResult = await downloadYouTubeAudio(url, tempDir);
+    const downloadResult = isYT
+      ? await downloadYouTubeAudio(url, tempDir)
+      : await downloadInstagramAudio(url, tempDir);
     const result = await transcribe(downloadResult.filePath, apiKey);
 
     console.log("\n" + chalk.green("--- Transcript ---"));

--- a/cli/src/instagram.test.ts
+++ b/cli/src/instagram.test.ts
@@ -1,0 +1,63 @@
+import { isInstagramUrl } from "./instagram";
+
+describe("isInstagramUrl", () => {
+  describe("valid Instagram URLs", () => {
+    it("matches a reel URL", () => {
+      expect(isInstagramUrl("https://www.instagram.com/reel/DYYLTCLNs6J/")).toBe(true);
+    });
+
+    it("matches a reels URL (plural)", () => {
+      expect(isInstagramUrl("https://www.instagram.com/reels/DYYLTCLNs6J/")).toBe(true);
+    });
+
+    it("matches a post URL (/p/)", () => {
+      expect(isInstagramUrl("https://www.instagram.com/p/DYYLTCLNs6J/")).toBe(true);
+    });
+
+    it("matches an IGTV URL (/tv/)", () => {
+      expect(isInstagramUrl("https://www.instagram.com/tv/DYYLTCLNs6J/")).toBe(true);
+    });
+
+    it("matches a URL with UTM query params", () => {
+      expect(
+        isInstagramUrl(
+          "https://www.instagram.com/reel/DYYLTCLNs6J/?utm_source=ig_web_copy_link&igsh=NTc4MTIwNjQ2YQ=="
+        )
+      ).toBe(true);
+    });
+
+    it("matches a URL without www", () => {
+      expect(isInstagramUrl("https://instagram.com/reel/DYYLTCLNs6J/")).toBe(true);
+    });
+
+    it("matches a URL without protocol", () => {
+      expect(isInstagramUrl("instagram.com/reel/DYYLTCLNs6J/")).toBe(true);
+    });
+
+    it("matches a URL with http", () => {
+      expect(isInstagramUrl("http://www.instagram.com/reel/DYYLTCLNs6J/")).toBe(true);
+    });
+  });
+
+  describe("invalid Instagram URLs", () => {
+    it("rejects a profile URL", () => {
+      expect(isInstagramUrl("https://www.instagram.com/someuser/")).toBe(false);
+    });
+
+    it("rejects a YouTube URL", () => {
+      expect(isInstagramUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).toBe(false);
+    });
+
+    it("rejects an empty string", () => {
+      expect(isInstagramUrl("")).toBe(false);
+    });
+
+    it("rejects a plain Instagram domain with no path", () => {
+      expect(isInstagramUrl("https://www.instagram.com/")).toBe(false);
+    });
+
+    it("rejects a local file path", () => {
+      expect(isInstagramUrl("/Users/me/video.mp4")).toBe(false);
+    });
+  });
+});

--- a/cli/src/instagram.ts
+++ b/cli/src/instagram.ts
@@ -1,0 +1,52 @@
+import * as path from "path";
+import { createSpinner } from "./utils";
+
+export interface InstagramDownloadResult {
+  filePath: string;
+  videoId: string;
+  title: string;
+}
+
+export async function downloadInstagramAudio(
+  url: string,
+  outputDir: string
+): Promise<InstagramDownloadResult> {
+  const spinner = createSpinner("Downloading audio from Instagram...");
+  spinner.start();
+
+  try {
+    const ytDlpModule = await import("yt-dlp-exec");
+    const ytDlp = ytDlpModule.default || ytDlpModule;
+
+    const info = await ytDlp(url, {
+      dumpSingleJson: true,
+      skipDownload: true,
+      noWarnings: true,
+    });
+
+    const videoId: string = info.id || "unknown";
+    const title: string = info.title || "untitled";
+    const outputPath = path.join(outputDir, `${videoId}.webm`);
+
+    await ytDlp(url, {
+      format: "bestaudio/best",
+      output: outputPath,
+      noWarnings: true,
+    });
+
+    spinner.succeed("Audio downloaded successfully");
+
+    return {
+      filePath: outputPath,
+      videoId,
+      title,
+    };
+  } catch (error) {
+    spinner.fail("Failed to download audio from Instagram");
+    throw error;
+  }
+}
+
+export function isInstagramUrl(url: string): boolean {
+  return /^(https?:\/\/)?(www\.)?instagram\.com\/(p|reel|tv)\/.+/.test(url);
+}

--- a/cli/src/instagram.ts
+++ b/cli/src/instagram.ts
@@ -48,5 +48,5 @@ export async function downloadInstagramAudio(
 }
 
 export function isInstagramUrl(url: string): boolean {
-  return /^(https?:\/\/)?(www\.)?instagram\.com\/(p|reel|tv)\/.+/.test(url);
+  return /^(https?:\/\/)?(www\.)?instagram\.com\/(p|reels?|tv)\/.+/.test(url);
 }


### PR DESCRIPTION
## Summary

- Adds `cli/src/instagram.ts` with `isInstagramUrl()` (supports `/p/`, `/reel/`, `/tv/` paths) and `downloadInstagramAudio()` using the existing `yt-dlp-exec` dependency — no new dependencies required
- Updates auto-detect in `index.ts` to recognise Instagram URLs alongside YouTube
- Updates `handleTranscribeUrl` to route to the correct downloader based on URL type; invalid URLs now show a clearer error message listing supported platforms
- Updates CLI description and `url` subcommand help text to mention Instagram

## Test plan

- [x] `transcribly <instagram-reel-url>` auto-detects and transcribes
- [x] `transcribly url <instagram-reel-url>` explicit subcommand works
- [x] `transcribly url <instagram-post-url>` (`/p/`) works
- [x] `transcribly <youtube-url>` still works (regression check)
- [x] `transcribly file <path>` still works (regression check)
- [x] Unsupported URL shows updated error message

Closes SOF-64