### PR TITLE
chore: release 1.1.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "transcribly",
-  "version": "1.0.3",
-  "description": "CLI tool to transcribe YouTube videos and local audio/video files using OpenAI Whisper API",
+  "version": "1.1.0",
+  "description": "CLI tool to transcribe YouTube videos, Instagram reels, and local audio/video files using OpenAI Whisper API",
   "main": "dist/index.js",
   "bin": {
     "transcribly": "dist/index.js"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -28,7 +28,7 @@ program
   .description(
     "Transcribe YouTube videos, Instagram reels, and local audio/video files using OpenAI Whisper API"
   )
-  .version("1.0.3");
+  .version("1.1.0");
 
 program
   .command("url <url>")


### PR DESCRIPTION
## Summary

Bumps version to `1.1.0` for npm publish.

### What's in this release

- Instagram Reels, posts, and IGTV transcription support (merged via #76)
- URL regex covers both `/reel/` and `/reels/` paths
- 13 new unit tests for Instagram URL detection
- Clearer unsupported-URL error messages
- Updated CLI description and help text

## Publish steps (after merge)

```bash
cd cli
npm run build
npm publish
```