### PR TITLE
feat: animated section backgrounds (constellation, deep space, grid)

### DIFF
--- a/client/src/components/landing/AIIntegrationSection.jsx
+++ b/client/src/components/landing/AIIntegrationSection.jsx
@@ -1,16 +1,18 @@
 import { motion } from "framer-motion";
 import ScrollReveal from "./ScrollReveal";
 import { usePackageManager, getRunCmd } from "../../context/PackageManagerContext";
+import DeepSpaceBackground from "./DeepSpaceBackground";
 
 export default function AIIntegrationSection() {
   const { pm } = usePackageManager();
   const runCmd = getRunCmd(pm);
 
   return (
-    <section className="border-t border-gray-800 bg-[#0a0a0a] px-6 py-24 font-mono">
-      <div className="mx-auto max-w-5xl text-center">
+    <section className="relative overflow-hidden bg-black px-6 py-24 font-mono">
+      <DeepSpaceBackground />
+      <div className="relative mx-auto max-w-5xl text-center">
         <ScrollReveal>
-          <span className="mb-4 inline-block rounded-full border border-gray-700 px-3 py-1 text-[10px] tracking-widest text-gray-500">
+          <span className="mb-4 inline-block rounded-full border border-gray-700 bg-[#0a0a0a]/80 px-3 py-1 text-[10px] tracking-widest text-gray-500 backdrop-blur">
             AI INTEGRATION
           </span>
           <h2 className="text-2xl font-bold text-white sm:text-3xl">
@@ -35,7 +37,7 @@ export default function AIIntegrationSection() {
                 y: -4,
               }}
               transition={{ duration: 0.25 }}
-              className="h-full rounded-xl border border-gray-800 bg-[#0f0f0f] p-7"
+              className="h-full rounded-xl border border-gray-800 bg-[#0f0f0f]/95 p-7 backdrop-blur-sm"
             >
               <div className="mb-5 flex items-center gap-3">
                 <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-sm">
@@ -109,7 +111,7 @@ export default function AIIntegrationSection() {
                 y: -4,
               }}
               transition={{ duration: 0.25 }}
-              className="h-full rounded-xl border border-gray-800 bg-[#0f0f0f] p-7"
+              className="h-full rounded-xl border border-gray-800 bg-[#0f0f0f]/95 p-7 backdrop-blur-sm"
             >
               <div className="mb-5 flex items-center gap-3">
                 <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-sm">

--- a/client/src/components/landing/CTASection.jsx
+++ b/client/src/components/landing/CTASection.jsx
@@ -9,15 +9,26 @@ export default function CTASection() {
   const runCmd = getRunCmd(pm);
 
   return (
-    <section className="relative overflow-hidden border-t border-gray-800 px-6 py-24 font-mono text-center">
-      {/* Grid background */}
+    <section
+      className="relative overflow-hidden px-6 py-24 font-mono text-center"
+      style={{
+        background:
+          "linear-gradient(to bottom, #000 0%, #0a0a0a 28%, #0a0a0a 100%)",
+      }}
+    >
+      {/* Grid background — masked so it fades in from the top */}
       <div
-        className="pointer-events-none absolute inset-0 opacity-30"
+        className="pointer-events-none absolute inset-0"
         aria-hidden="true"
         style={{
           backgroundImage:
             "linear-gradient(#1a1a1a 1px, transparent 1px), linear-gradient(90deg, #1a1a1a 1px, transparent 1px)",
           backgroundSize: "40px 40px",
+          maskImage:
+            "linear-gradient(to bottom, transparent 0%, #000 32%, #000 100%)",
+          WebkitMaskImage:
+            "linear-gradient(to bottom, transparent 0%, #000 32%, #000 100%)",
+          opacity: 0.35,
         }}
       />
       {/* Green glow */}

--- a/client/src/components/landing/CodeRainBackground.jsx
+++ b/client/src/components/landing/CodeRainBackground.jsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from "react";
+
+export default function CodeRainBackground({
+  opacity = 0.3,
+  density = 1,
+  speed = 1,
+  color = "74,222,128",
+  vignette = true,
+}) {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    const fontSize = 14;
+    const chars = "01{}[]()<>/\\=+-*;:&|!?".split("");
+    let w = 0;
+    let h = 0;
+    let columns = 0;
+    let drops = [];
+    let active = [];
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      w = canvas.clientWidth;
+      h = canvas.clientHeight;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.scale(dpr, dpr);
+      columns = Math.floor(w / fontSize);
+      drops = Array(columns).fill(0).map(() => Math.random() * -h);
+      active = Array(columns).fill(0).map(() => Math.random() < density);
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+
+    let raf;
+    const draw = () => {
+      ctx.fillStyle = "rgba(10,10,10,0.08)";
+      ctx.fillRect(0, 0, w, h);
+      ctx.fillStyle = `rgba(${color},0.35)`;
+      ctx.font = `${fontSize}px JetBrains Mono, ui-monospace, monospace`;
+      for (let i = 0; i < columns; i++) {
+        if (!active[i]) continue;
+        const c = chars[Math.floor(Math.random() * chars.length)];
+        ctx.fillText(c, i * fontSize, drops[i]);
+        if (drops[i] > h && Math.random() > 0.985) drops[i] = 0;
+        drops[i] += fontSize * 0.4 * speed;
+      }
+      if (!reduce) raf = requestAnimationFrame(draw);
+    };
+    draw();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, [density, speed, color]);
+
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      <canvas
+        ref={canvasRef}
+        className="absolute inset-0 h-full w-full"
+        style={{ opacity }}
+      />
+      {vignette && (
+        <>
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                "radial-gradient(ellipse at 50% 60%, transparent 0%, rgba(10,10,10,0.85) 70%, #0a0a0a 100%)",
+            }}
+          />
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                "linear-gradient(to bottom, #0a0a0a 0%, transparent 14%, transparent 86%, #0a0a0a 100%)",
+            }}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/landing/ConstellationBackground.jsx
+++ b/client/src/components/landing/ConstellationBackground.jsx
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from "react";
+
+export default function ConstellationBackground({
+  nodeCount = 36,
+  linkDist = 140,
+  speed = 1,
+  color = "74,222,128",
+  vignette = true,
+}) {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    let w = 0;
+    let h = 0;
+    let nodes = [];
+    let raf;
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      w = canvas.clientWidth;
+      h = canvas.clientHeight;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.scale(dpr, dpr);
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+
+    nodes = Array.from({ length: nodeCount }, () => ({
+      x: Math.random() * w,
+      y: Math.random() * h,
+      vx: (Math.random() - 0.5) * 0.15 * speed,
+      vy: (Math.random() - 0.5) * 0.15 * speed,
+      phase: Math.random() * Math.PI * 2,
+    }));
+
+    const draw = (t) => {
+      ctx.clearRect(0, 0, w, h);
+      for (let i = 0; i < nodes.length; i++) {
+        for (let j = i + 1; j < nodes.length; j++) {
+          const a = nodes[i];
+          const b = nodes[j];
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const d = Math.hypot(dx, dy);
+          if (d < linkDist) {
+            const alpha = (1 - d / linkDist) * 0.12;
+            ctx.strokeStyle = `rgba(${color},${alpha})`;
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+          }
+        }
+      }
+      for (const n of nodes) {
+        if (!reduce) {
+          n.x += n.vx;
+          n.y += n.vy;
+          if (n.x < 0 || n.x > w) n.vx *= -1;
+          if (n.y < 0 || n.y > h) n.vy *= -1;
+        }
+        const pulse = 0.5 + 0.5 * Math.sin(t / 800 + n.phase);
+        ctx.fillStyle = `rgba(${color},${0.25 + 0.35 * pulse})`;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, 1.4 + pulse * 0.8, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      if (!reduce) raf = requestAnimationFrame(draw);
+    };
+    raf = requestAnimationFrame(draw);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, [nodeCount, linkDist, speed, color]);
+
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
+      {vignette && (
+        <>
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                "radial-gradient(ellipse at center, transparent 0%, transparent 55%, #0a0a0a 100%)",
+            }}
+          />
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                "linear-gradient(to bottom, #000 0%, transparent 25%, transparent 92%, #000 100%)",
+            }}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/landing/ConstellationBackground.jsx
+++ b/client/src/components/landing/ConstellationBackground.jsx
@@ -27,6 +27,10 @@ export default function ConstellationBackground({
       canvas.height = h * dpr;
       ctx.setTransform(1, 0, 0, 1, 0, 0);
       ctx.scale(dpr, dpr);
+      for (const n of nodes) {
+        n.x = Math.min(n.x, w);
+        n.y = Math.min(n.y, h);
+      }
     };
     resize();
     const ro = new ResizeObserver(resize);

--- a/client/src/components/landing/DeepSpaceBackground.jsx
+++ b/client/src/components/landing/DeepSpaceBackground.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from "react";
+
+export default function DeepSpaceBackground({
+  starCount = 140,
+  color = "180,220,200",
+  fadeTop = true,
+  fadeBottom = true,
+}) {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    let w = 0;
+    let h = 0;
+    let stars = [];
+    let raf;
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      w = canvas.clientWidth;
+      h = canvas.clientHeight;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.scale(dpr, dpr);
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+
+    stars = Array.from({ length: starCount }, () => ({
+      x: Math.random(),
+      y: Math.random(),
+      r: 0.4 + Math.random() * 1.4,
+      base: 0.15 + Math.random() * 0.55,
+      twinkleSpeed: 0.0004 + Math.random() * 0.0012,
+      phase: Math.random() * Math.PI * 2,
+      bright: Math.random() < 0.08,
+    }));
+
+    const draw = (t) => {
+      ctx.clearRect(0, 0, w, h);
+      for (const s of stars) {
+        const tw = 0.5 + 0.5 * Math.sin(t * s.twinkleSpeed + s.phase);
+        const alpha = s.base * (0.5 + tw * 0.5);
+        const r = s.r * (s.bright ? 1.6 : 1);
+        const px = s.x * w;
+        const py = s.y * h;
+        if (s.bright) {
+          const g = ctx.createRadialGradient(px, py, 0, px, py, r * 6);
+          g.addColorStop(0, `rgba(${color},${alpha * 0.6})`);
+          g.addColorStop(1, `rgba(${color},0)`);
+          ctx.fillStyle = g;
+          ctx.beginPath();
+          ctx.arc(px, py, r * 6, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        ctx.fillStyle = `rgba(${color},${alpha})`;
+        ctx.beginPath();
+        ctx.arc(px, py, r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      if (!reduce) raf = requestAnimationFrame(draw);
+    };
+    raf = requestAnimationFrame(draw);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, [starCount, color]);
+
+  const stops = [];
+  if (fadeTop) stops.push("#000 0%", "transparent 18%");
+  else stops.push("transparent 0%");
+  if (fadeBottom) stops.push("transparent 80%", "#000 100%");
+  else stops.push("transparent 100%");
+
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
+      <div
+        className="absolute inset-0"
+        style={{ background: `linear-gradient(to bottom, ${stops.join(", ")})` }}
+      />
+    </div>
+  );
+}

--- a/client/src/components/landing/FeaturesSection.jsx
+++ b/client/src/components/landing/FeaturesSection.jsx
@@ -1,6 +1,7 @@
 import { motion } from "framer-motion";
 import ScrollReveal from "./ScrollReveal";
 import { usePackageManager, getRunCmd } from "../../context/PackageManagerContext";
+import ConstellationBackground from "./ConstellationBackground";
 
 export default function FeaturesSection() {
   const { pm } = usePackageManager();
@@ -31,10 +32,17 @@ export default function FeaturesSection() {
   ];
 
   return (
-    <section className="border-t border-gray-800 bg-[#0a0a0a] px-6 py-24 font-mono">
-      <div className="mx-auto max-w-5xl text-center">
+    <section
+      className="relative overflow-hidden px-6 py-24 font-mono"
+      style={{
+        background:
+          "linear-gradient(to bottom, #000 0%, #0a0a0a 28%, #0a0a0a 70%, #000 100%)",
+      }}
+    >
+      <ConstellationBackground />
+      <div className="relative mx-auto max-w-5xl text-center">
         <ScrollReveal>
-          <span className="mb-4 inline-block rounded-full border border-gray-700 px-3 py-1 text-[10px] tracking-widest text-gray-500">
+          <span className="mb-4 inline-block rounded-full border border-gray-700 bg-[#0a0a0a]/80 px-3 py-1 text-[10px] tracking-widest text-gray-500 backdrop-blur">
             WHY TRANSCRIBLY
           </span>
           <h2 className="text-2xl font-bold text-white sm:text-3xl">
@@ -54,7 +62,7 @@ export default function FeaturesSection() {
                   y: -4,
                 }}
                 transition={{ duration: 0.25 }}
-                className="h-full rounded-xl border border-gray-800 bg-[#0f0f0f] p-7"
+                className="h-full rounded-xl border border-gray-800 bg-[#0f0f0f]/95 p-7 backdrop-blur-sm"
               >
                 <div className="mb-4 text-2xl text-green-400">{f.icon}</div>
                 <h3 className="mb-2 text-sm font-bold text-white">

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -22,20 +22,47 @@ class IntersectionObserver {
 }
 window.IntersectionObserver = IntersectionObserver;
 
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+window.ResizeObserver = ResizeObserver;
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
 HTMLCanvasElement.prototype.getContext = function () {
   return {
     clearRect: () => {},
+    fillRect: () => {},
     beginPath: () => {},
     arc: () => {},
     fill: () => {},
+    stroke: () => {},
     moveTo: () => {},
     lineTo: () => {},
     quadraticCurveTo: () => {},
     closePath: () => {},
+    fillText: () => {},
+    setTransform: () => {},
+    scale: () => {},
     fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    font: '',
     shadowBlur: 0,
     shadowColor: '',
-    scale: () => {},
     createLinearGradient: () => ({ addColorStop: () => {} }),
+    createRadialGradient: () => ({ addColorStop: () => {} }),
   };
 };


### PR DESCRIPTION
## Summary

- **FeaturesSection** — adds `ConstellationBackground`: pulsing green dots connected by faint lines, evoking a pipeline/graph feel
- **AIIntegrationSection** — adds `DeepSpaceBackground`: sparse twinkling starfield with a handful of halo'd brighter stars on a pure black section bg
- **CTASection** — retunes the existing grid pattern with a top mask so it fades in from black instead of cutting in hard
- All three section backgrounds use coordinated dark gradients (`#000 → #0a0a0a → #000`) so section boundaries are color-seamless — no `border-t` lines, no visible seams
- Cards get `backdrop-blur-sm` and `bg-opacity-95` so they remain fully readable over the animations
- All three canvas components respect `prefers-reduced-motion`

## New files

| File | Purpose |
|---|---|
| `ConstellationBackground.jsx` | Floating connected dots canvas |
| `DeepSpaceBackground.jsx` | Twinkling starfield canvas |
| `CodeRainBackground.jsx` | Matrix-style fall canvas (in kit, not used on live page) |

## Reviewer notes

- No new dependencies — plain `<canvas>` + `useEffect`
- No Tailwind config changes
- Canvas is sized to the section, not the viewport — only paints what's on screen
- Animations stop on the first frame under `prefers-reduced-motion: reduce`